### PR TITLE
Add support for Exadata feature

### DIFF
--- a/docs/data-sources/availability_machine.md
+++ b/docs/data-sources/availability_machine.md
@@ -148,7 +148,7 @@ Read-Only:
 - `volume_type` (String)
 
 <a id="nestedobjatt--clones--instances--archive_storage_config--azure_net_app_config"></a>
-### Nested Schema for `clones.instances.archive_storage_config.volume_type`
+### Nested Schema for `clones.instances.archive_storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -158,13 +158,13 @@ Read-Only:
 - `capacity_pool_name` (String)
 - `delegated_subnet_id` (String)
 - `delegated_subnet_name` (String)
-- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--clones--instances--archive_storage_config--volume_type--encryption_key_info))
+- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--clones--instances--archive_storage_config--azure_net_app_config--encryption_key_info))
 - `network_features` (String)
 - `service_level` (String)
 - `volume_name` (String)
 
-<a id="nestedobjatt--clones--instances--archive_storage_config--volume_type--encryption_key_info"></a>
-### Nested Schema for `clones.instances.archive_storage_config.volume_type.encryption_key_info`
+<a id="nestedobjatt--clones--instances--archive_storage_config--azure_net_app_config--encryption_key_info"></a>
+### Nested Schema for `clones.instances.archive_storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -176,7 +176,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--clones--instances--archive_storage_config--fsx_net_app_config"></a>
-### Nested Schema for `clones.instances.archive_storage_config.volume_type`
+### Nested Schema for `clones.instances.archive_storage_config.fsx_net_app_config`
 
 Read-Only:
 
@@ -213,7 +213,7 @@ Read-Only:
 - `provider` (String)
 
 <a id="nestedobjatt--clones--instances--compute_config--exadata_config"></a>
-### Nested Schema for `clones.instances.compute_config.provider`
+### Nested Schema for `clones.instances.compute_config.exadata_config`
 
 Read-Only:
 
@@ -317,7 +317,7 @@ Read-Only:
 - `volume_type` (String)
 
 <a id="nestedobjatt--clones--instances--storage_config--azure_net_app_config"></a>
-### Nested Schema for `clones.instances.storage_config.volume_type`
+### Nested Schema for `clones.instances.storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -327,13 +327,13 @@ Read-Only:
 - `capacity_pool_name` (String)
 - `delegated_subnet_id` (String)
 - `delegated_subnet_name` (String)
-- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--clones--instances--storage_config--volume_type--encryption_key_info))
+- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--clones--instances--storage_config--azure_net_app_config--encryption_key_info))
 - `network_features` (String)
 - `service_level` (String)
 - `volume_name` (String)
 
-<a id="nestedobjatt--clones--instances--storage_config--volume_type--encryption_key_info"></a>
-### Nested Schema for `clones.instances.storage_config.volume_type.encryption_key_info`
+<a id="nestedobjatt--clones--instances--storage_config--azure_net_app_config--encryption_key_info"></a>
+### Nested Schema for `clones.instances.storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -345,7 +345,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--clones--instances--storage_config--fsx_net_app_config"></a>
-### Nested Schema for `clones.instances.storage_config.volume_type`
+### Nested Schema for `clones.instances.storage_config.fsx_net_app_config`
 
 Read-Only:
 
@@ -467,7 +467,7 @@ Read-Only:
 - `manual` (List of Object) (see [below for nested schema](#nestedobjatt--daps--content_info--sanitized_content--manual))
 
 <a id="nestedobjatt--daps--content_info--sanitized_content--automated"></a>
-### Nested Schema for `daps.content_info.sanitized_content.manual`
+### Nested Schema for `daps.content_info.sanitized_content.automated`
 
 Read-Only:
 
@@ -599,7 +599,7 @@ Read-Only:
 - `month_specific_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule--month_specific_schedule))
 
 <a id="nestedobjatt--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule--common_schedule"></a>
-### Nested Schema for `rpo_policy.backup_rpo_config.custom_policy.schedule.yearly_schedule.month_specific_schedule`
+### Nested Schema for `rpo_policy.backup_rpo_config.custom_policy.schedule.yearly_schedule.common_schedule`
 
 Read-Only:
 
@@ -629,7 +629,7 @@ Read-Only:
 - `weekly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--rpo_policy--backup_rpo_config--full_backup_schedule--weekly_schedule))
 
 <a id="nestedobjatt--rpo_policy--backup_rpo_config--full_backup_schedule--start_time"></a>
-### Nested Schema for `rpo_policy.backup_rpo_config.full_backup_schedule.weekly_schedule`
+### Nested Schema for `rpo_policy.backup_rpo_config.full_backup_schedule.start_time`
 
 Read-Only:
 
@@ -655,7 +655,7 @@ Read-Only:
 - `retention_days` (Number)
 
 <a id="nestedobjatt--rpo_policy--backup_rpo_config--standard_policy--backup_start_time"></a>
-### Nested Schema for `rpo_policy.backup_rpo_config.standard_policy.retention_days`
+### Nested Schema for `rpo_policy.backup_rpo_config.standard_policy.backup_start_time`
 
 Read-Only:
 
@@ -685,7 +685,7 @@ Read-Only:
 - `yearly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--rpo_policy--custom_policy--schedule--yearly_schedule))
 
 <a id="nestedobjatt--rpo_policy--custom_policy--schedule--backup_start_time"></a>
-### Nested Schema for `rpo_policy.custom_policy.schedule.yearly_schedule`
+### Nested Schema for `rpo_policy.custom_policy.schedule.backup_start_time`
 
 Read-Only:
 
@@ -694,7 +694,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--rpo_policy--custom_policy--schedule--daily_schedule"></a>
-### Nested Schema for `rpo_policy.custom_policy.schedule.yearly_schedule`
+### Nested Schema for `rpo_policy.custom_policy.schedule.daily_schedule`
 
 Read-Only:
 
@@ -702,14 +702,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--rpo_policy--custom_policy--schedule--monthly_schedule"></a>
-### Nested Schema for `rpo_policy.custom_policy.schedule.yearly_schedule`
+### Nested Schema for `rpo_policy.custom_policy.schedule.monthly_schedule`
 
 Read-Only:
 
-- `common_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--rpo_policy--custom_policy--schedule--yearly_schedule--common_schedule))
+- `common_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--rpo_policy--custom_policy--schedule--monthly_schedule--common_schedule))
 
-<a id="nestedobjatt--rpo_policy--custom_policy--schedule--yearly_schedule--common_schedule"></a>
-### Nested Schema for `rpo_policy.custom_policy.schedule.yearly_schedule.common_schedule`
+<a id="nestedobjatt--rpo_policy--custom_policy--schedule--monthly_schedule--common_schedule"></a>
+### Nested Schema for `rpo_policy.custom_policy.schedule.monthly_schedule.common_schedule`
 
 Read-Only:
 
@@ -719,7 +719,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--rpo_policy--custom_policy--schedule--weekly_schedule"></a>
-### Nested Schema for `rpo_policy.custom_policy.schedule.yearly_schedule`
+### Nested Schema for `rpo_policy.custom_policy.schedule.weekly_schedule`
 
 Read-Only:
 
@@ -865,5 +865,3 @@ Read-Only:
 - `cloud_type` (String)
 - `region` (String)
 - `type` (String)
-
-

--- a/docs/data-sources/availability_machines.md
+++ b/docs/data-sources/availability_machines.md
@@ -154,17 +154,17 @@ Read-Only:
 - `vpc` (String)
 
 <a id="nestedobjatt--availability_machines--clones--instances--archive_storage_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.archive_storage_config`
 
 Read-Only:
 
-- `azure_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config))
-- `fsx_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--fsx_net_app_config))
+- `azure_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--archive_storage_config--azure_net_app_config))
+- `fsx_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--archive_storage_config--fsx_net_app_config))
 - `provider` (String)
 - `volume_type` (String)
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.azure_net_app_config`
+<a id="nestedobjatt--availability_machines--clones--instances--archive_storage_config--azure_net_app_config"></a>
+### Nested Schema for `availability_machines.clones.instances.archive_storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -174,13 +174,13 @@ Read-Only:
 - `capacity_pool_name` (String)
 - `delegated_subnet_id` (String)
 - `delegated_subnet_name` (String)
-- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config--encryption_key_info))
+- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--archive_storage_config--azure_net_app_config--encryption_key_info))
 - `network_features` (String)
 - `service_level` (String)
 - `volume_name` (String)
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config--encryption_key_info"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.azure_net_app_config.volume_name`
+<a id="nestedobjatt--availability_machines--clones--instances--archive_storage_config--azure_net_app_config--encryption_key_info"></a>
+### Nested Schema for `availability_machines.clones.instances.archive_storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -191,8 +191,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--fsx_net_app_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.fsx_net_app_config`
+<a id="nestedobjatt--availability_machines--clones--instances--archive_storage_config--fsx_net_app_config"></a>
+### Nested Schema for `availability_machines.clones.instances.archive_storage_config.fsx_net_app_config`
 
 Read-Only:
 
@@ -205,14 +205,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--aws_infra_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.aws_infra_config`
 
 Read-Only:
 
-- `aws_cpu_options` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--aws_cpu_options))
+- `aws_cpu_options` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--aws_infra_config--aws_cpu_options))
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--aws_cpu_options"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.aws_cpu_options`
+<a id="nestedobjatt--availability_machines--clones--instances--aws_infra_config--aws_cpu_options"></a>
+### Nested Schema for `availability_machines.clones.instances.aws_infra_config.aws_cpu_options`
 
 Read-Only:
 
@@ -221,15 +221,15 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--compute_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.compute_config`
 
 Read-Only:
 
-- `exadata_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--exadata_config))
+- `exadata_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--compute_config--exadata_config))
 - `provider` (String)
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--exadata_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.exadata_config`
+<a id="nestedobjatt--availability_machines--clones--instances--compute_config--exadata_config"></a>
+### Nested Schema for `availability_machines.clones.instances.compute_config.exadata_config`
 
 Read-Only:
 
@@ -243,7 +243,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--connect_string"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.connect_string`
 
 Read-Only:
 
@@ -254,14 +254,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--engine_configuration"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.engine_configuration`
 
 Read-Only:
 
-- `oracle_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--oracle_config))
+- `oracle_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--engine_configuration--oracle_config))
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--oracle_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.oracle_config`
+<a id="nestedobjatt--availability_machines--clones--instances--engine_configuration--oracle_config"></a>
+### Nested Schema for `availability_machines.clones.instances.engine_configuration.oracle_config`
 
 Read-Only:
 
@@ -270,14 +270,14 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--monitoring_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.monitoring_config`
 
 Read-Only:
 
-- `perf_insights` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--perf_insights))
+- `perf_insights` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--monitoring_config--perf_insights))
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--perf_insights"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.perf_insights`
+<a id="nestedobjatt--availability_machines--clones--instances--monitoring_config--perf_insights"></a>
+### Nested Schema for `availability_machines.clones.instances.monitoring_config.perf_insights`
 
 Read-Only:
 
@@ -288,7 +288,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--option_profile"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.option_profile`
 
 Read-Only:
 
@@ -299,7 +299,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--parameter_profile"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.parameter_profile`
 
 Read-Only:
 
@@ -310,7 +310,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--private_link_info"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.private_link_info`
 
 Read-Only:
 
@@ -323,17 +323,17 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--storage_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.storage_config`
 
 Read-Only:
 
-- `azure_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config))
-- `fsx_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--fsx_net_app_config))
+- `azure_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--storage_config--azure_net_app_config))
+- `fsx_net_app_config` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--storage_config--fsx_net_app_config))
 - `provider` (String)
 - `volume_type` (String)
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.azure_net_app_config`
+<a id="nestedobjatt--availability_machines--clones--instances--storage_config--azure_net_app_config"></a>
+### Nested Schema for `availability_machines.clones.instances.storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -343,13 +343,13 @@ Read-Only:
 - `capacity_pool_name` (String)
 - `delegated_subnet_id` (String)
 - `delegated_subnet_name` (String)
-- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config--encryption_key_info))
+- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--clones--instances--storage_config--azure_net_app_config--encryption_key_info))
 - `network_features` (String)
 - `service_level` (String)
 - `volume_name` (String)
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--azure_net_app_config--encryption_key_info"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.azure_net_app_config.volume_name`
+<a id="nestedobjatt--availability_machines--clones--instances--storage_config--azure_net_app_config--encryption_key_info"></a>
+### Nested Schema for `availability_machines.clones.instances.storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -360,8 +360,8 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--availability_machines--clones--instances--vpc--fsx_net_app_config"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc.fsx_net_app_config`
+<a id="nestedobjatt--availability_machines--clones--instances--storage_config--fsx_net_app_config"></a>
+### Nested Schema for `availability_machines.clones.instances.storage_config.fsx_net_app_config`
 
 Read-Only:
 
@@ -374,7 +374,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--clones--instances--updates_in_progress"></a>
-### Nested Schema for `availability_machines.clones.instances.vpc`
+### Nested Schema for `availability_machines.clones.instances.updates_in_progress`
 
 Read-Only:
 
@@ -435,15 +435,15 @@ Read-Only:
 - `sanitized_content` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--daps--content_info--sanitized_content))
 
 <a id="nestedobjatt--availability_machines--daps--content_info--as_is_content"></a>
-### Nested Schema for `availability_machines.daps.content_info.sanitized_content`
+### Nested Schema for `availability_machines.daps.content_info.as_is_content`
 
 Read-Only:
 
 - `automated` (Boolean)
-- `manual` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--daps--content_info--sanitized_content--manual))
+- `manual` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--daps--content_info--as_is_content--manual))
 
-<a id="nestedobjatt--availability_machines--daps--content_info--sanitized_content--manual"></a>
-### Nested Schema for `availability_machines.daps.content_info.sanitized_content.manual`
+<a id="nestedobjatt--availability_machines--daps--content_info--as_is_content--manual"></a>
+### Nested Schema for `availability_machines.daps.content_info.as_is_content.manual`
 
 Read-Only:
 
@@ -455,15 +455,15 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--daps--content_info--backup_content"></a>
-### Nested Schema for `availability_machines.daps.content_info.sanitized_content`
+### Nested Schema for `availability_machines.daps.content_info.backup_content`
 
 Read-Only:
 
 - `automated` (Boolean)
-- `manual` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--daps--content_info--sanitized_content--manual))
+- `manual` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--daps--content_info--backup_content--manual))
 
-<a id="nestedobjatt--availability_machines--daps--content_info--sanitized_content--manual"></a>
-### Nested Schema for `availability_machines.daps.content_info.sanitized_content.manual`
+<a id="nestedobjatt--availability_machines--daps--content_info--backup_content--manual"></a>
+### Nested Schema for `availability_machines.daps.content_info.backup_content.manual`
 
 Read-Only:
 
@@ -546,26 +546,26 @@ Read-Only:
 - `standard_policy` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy))
 
 <a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy`
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy`
 
 Read-Only:
 
 - `name` (String)
-- `schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule))
+- `schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule))
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule`
 
 Read-Only:
 
-- `backup_start_time` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--backup_start_time))
-- `daily_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--daily_schedule))
-- `monthly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--monthly_schedule))
-- `weekly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--weekly_schedule))
-- `yearly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule))
+- `backup_start_time` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--backup_start_time))
+- `daily_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--daily_schedule))
+- `monthly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--monthly_schedule))
+- `weekly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--weekly_schedule))
+- `yearly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule))
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--backup_start_time"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--backup_start_time"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.backup_start_time`
 
 Read-Only:
 
@@ -573,23 +573,23 @@ Read-Only:
 - `minute` (Number)
 
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--daily_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--daily_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.daily_schedule`
 
 Read-Only:
 
 - `backups_per_day` (Number)
 
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--monthly_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--monthly_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.monthly_schedule`
 
 Read-Only:
 
-- `common_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule--common_schedule))
+- `common_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--monthly_schedule--common_schedule))
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule--common_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule.common_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--monthly_schedule--common_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.monthly_schedule.common_schedule`
 
 Read-Only:
 
@@ -598,24 +598,24 @@ Read-Only:
 
 
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--weekly_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--weekly_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.weekly_schedule`
 
 Read-Only:
 
 - `days` (List of String)
 
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.yearly_schedule`
 
 Read-Only:
 
-- `common_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule--common_schedule))
-- `month_specific_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule--month_specific_schedule))
+- `common_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule--common_schedule))
+- `month_specific_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule--month_specific_schedule))
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule--common_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule.month_specific_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule--common_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.yearly_schedule.common_schedule`
 
 Read-Only:
 
@@ -624,8 +624,8 @@ Read-Only:
 - `months` (List of String)
 
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--schedule--yearly_schedule--month_specific_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.schedule.yearly_schedule.month_specific_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--custom_policy--schedule--yearly_schedule--month_specific_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.custom_policy.schedule.yearly_schedule.month_specific_schedule`
 
 Read-Only:
 
@@ -637,15 +637,15 @@ Read-Only:
 
 
 <a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--full_backup_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy`
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.full_backup_schedule`
 
 Read-Only:
 
-- `start_time` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--start_time))
-- `weekly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--weekly_schedule))
+- `start_time` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--full_backup_schedule--start_time))
+- `weekly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--full_backup_schedule--weekly_schedule))
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--start_time"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.start_time`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--full_backup_schedule--start_time"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.full_backup_schedule.start_time`
 
 Read-Only:
 
@@ -653,8 +653,8 @@ Read-Only:
 - `minute` (Number)
 
 
-<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--standard_policy--weekly_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.standard_policy.weekly_schedule`
+<a id="nestedobjatt--availability_machines--rpo_policy--backup_rpo_config--full_backup_schedule--weekly_schedule"></a>
+### Nested Schema for `availability_machines.rpo_policy.backup_rpo_config.full_backup_schedule.weekly_schedule`
 
 Read-Only:
 
@@ -751,7 +751,7 @@ Read-Only:
 - `month_specific_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--custom_policy--schedule--yearly_schedule--month_specific_schedule))
 
 <a id="nestedobjatt--availability_machines--rpo_policy--custom_policy--schedule--yearly_schedule--common_schedule"></a>
-### Nested Schema for `availability_machines.rpo_policy.custom_policy.schedule.yearly_schedule.month_specific_schedule`
+### Nested Schema for `availability_machines.rpo_policy.custom_policy.schedule.yearly_schedule.common_schedule`
 
 Read-Only:
 
@@ -781,7 +781,7 @@ Read-Only:
 - `weekly_schedule` (List of Object) (see [below for nested schema](#nestedobjatt--availability_machines--rpo_policy--full_backup_schedule--weekly_schedule))
 
 <a id="nestedobjatt--availability_machines--rpo_policy--full_backup_schedule--start_time"></a>
-### Nested Schema for `availability_machines.rpo_policy.full_backup_schedule.weekly_schedule`
+### Nested Schema for `availability_machines.rpo_policy.full_backup_schedule.start_time`
 
 Read-Only:
 
@@ -881,5 +881,3 @@ Read-Only:
 - `cloud_type` (String)
 - `region` (String)
 - `type` (String)
-
-

--- a/docs/data-sources/dataflix.md
+++ b/docs/data-sources/dataflix.md
@@ -62,5 +62,3 @@ Read-Only:
 Read-Only:
 
 - `users` (List of String)
-
-

--- a/docs/data-sources/dataflix_catalog.md
+++ b/docs/data-sources/dataflix_catalog.md
@@ -63,7 +63,7 @@ Read-Only:
 - `to_time` (String)
 
 <a id="nestedobjatt--pitr_catalog--regions--time_ranges--shared_with"></a>
-### Nested Schema for `pitr_catalog.regions.time_ranges.to_time`
+### Nested Schema for `pitr_catalog.regions.time_ranges.shared_with`
 
 Read-Only:
 
@@ -125,5 +125,3 @@ Read-Only:
 Read-Only:
 
 - `users` (List of String)
-
-

--- a/docs/data-sources/dataflixes.md
+++ b/docs/data-sources/dataflixes.md
@@ -70,5 +70,3 @@ Read-Only:
 Read-Only:
 
 - `users` (List of String)
-
-

--- a/docs/data-sources/db_backups.md
+++ b/docs/data-sources/db_backups.md
@@ -132,10 +132,8 @@ Read-Only:
 - `user_email` (String)
 
 <a id="nestedobjatt--db_backups--shared_with--users--expiry_config"></a>
-### Nested Schema for `db_backups.shared_with.users.user_email`
+### Nested Schema for `db_backups.shared_with.users.expiry_config`
 
 Read-Only:
 
 - `expire_at` (String)
-
-

--- a/docs/data-sources/db_parameter_profiles.md
+++ b/docs/data-sources/db_parameter_profiles.md
@@ -102,5 +102,3 @@ Read-Only:
 - `source` (String)
 - `top_parameter` (Boolean)
 - `value` (String)
-
-

--- a/docs/data-sources/db_service.md
+++ b/docs/data-sources/db_service.md
@@ -83,6 +83,7 @@ Read-Only:
 - `snapshot_id` (String)
 - `snapshot_name` (String)
 - `snapshot_time` (String)
+- `storage_provider` (String)
 - `tessell_service` (String)
 - `tessell_service_id` (String)
 
@@ -318,7 +319,7 @@ Read-Only:
 
 - `ad_domain_id` (String)
 - `option_profile_id` (String)
-- `options_profile` (String)
+- `option_profile_name` (String)
 - `parameter_profile_id` (String)
 - `proxy_port` (Number)
 
@@ -339,6 +340,7 @@ Read-Only:
 
 - `ad_domain_id` (String)
 - `agent_service_account_user` (String)
+- `instance_name` (String)
 - `parameter_profile_id` (String)
 - `service_account_user` (String)
 
@@ -511,7 +513,7 @@ Read-Only:
 - `volume_name` (String)
 
 <a id="nestedobjatt--instances--archive_storage_config--azure_net_app_config--encryption_key_info"></a>
-### Nested Schema for `instances.archive_storage_config.azure_net_app_config.volume_name`
+### Nested Schema for `instances.archive_storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -680,7 +682,7 @@ Read-Only:
 - `volume_name` (String)
 
 <a id="nestedobjatt--instances--storage_config--azure_net_app_config--encryption_key_info"></a>
-### Nested Schema for `instances.storage_config.azure_net_app_config.volume_name`
+### Nested Schema for `instances.storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -947,5 +949,3 @@ Read-Only:
 - `submitted_at` (String)
 - `update_info` (Map of String)
 - `update_type` (String)
-
-

--- a/docs/data-sources/db_service_delete_schedule.md
+++ b/docs/data-sources/db_service_delete_schedule.md
@@ -32,5 +32,3 @@ data "tessell_db_service_delete_schedule" "example" {
 Read-Only:
 
 - `retain_availability_machine` (Boolean)
-
-

--- a/docs/data-sources/db_services.md
+++ b/docs/data-sources/db_services.md
@@ -103,6 +103,7 @@ Read-Only:
 - `snapshot_id` (String)
 - `snapshot_name` (String)
 - `snapshot_time` (String)
+- `storage_provider` (String)
 - `tessell_service` (String)
 - `tessell_service_id` (String)
 
@@ -165,7 +166,7 @@ Read-Only:
 - `sql_server_config` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--databases--database_configuration--sql_server_config))
 
 <a id="nestedobjatt--db_services--databases--database_configuration--milvus_config"></a>
-### Nested Schema for `db_services.databases.database_configuration.sql_server_config`
+### Nested Schema for `db_services.databases.database_configuration.milvus_config`
 
 Read-Only:
 
@@ -173,7 +174,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--db_services--databases--database_configuration--mongodb_config"></a>
-### Nested Schema for `db_services.databases.database_configuration.sql_server_config`
+### Nested Schema for `db_services.databases.database_configuration.mongodb_config`
 
 Read-Only:
 
@@ -181,7 +182,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--db_services--databases--database_configuration--mysql_config"></a>
-### Nested Schema for `db_services.databases.database_configuration.sql_server_config`
+### Nested Schema for `db_services.databases.database_configuration.mysql_config`
 
 Read-Only:
 
@@ -190,7 +191,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--db_services--databases--database_configuration--oracle_config"></a>
-### Nested Schema for `db_services.databases.database_configuration.sql_server_config`
+### Nested Schema for `db_services.databases.database_configuration.oracle_config`
 
 Read-Only:
 
@@ -201,7 +202,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--db_services--databases--database_configuration--postgresql_config"></a>
-### Nested Schema for `db_services.databases.database_configuration.sql_server_config`
+### Nested Schema for `db_services.databases.database_configuration.postgresql_config`
 
 Read-Only:
 
@@ -338,7 +339,7 @@ Read-Only:
 
 - `ad_domain_id` (String)
 - `option_profile_id` (String)
-- `options_profile` (String)
+- `option_profile_name` (String)
 - `parameter_profile_id` (String)
 - `proxy_port` (Number)
 
@@ -359,6 +360,7 @@ Read-Only:
 
 - `ad_domain_id` (String)
 - `agent_service_account_user` (String)
+- `instance_name` (String)
 - `parameter_profile_id` (String)
 - `service_account_user` (String)
 
@@ -399,7 +401,7 @@ Read-Only:
 - `provider` (String)
 
 <a id="nestedobjatt--db_services--infrastructure--archive_storage_config--azure_net_app_config"></a>
-### Nested Schema for `db_services.infrastructure.archive_storage_config.provider`
+### Nested Schema for `db_services.infrastructure.archive_storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -450,7 +452,7 @@ Read-Only:
 - `provider` (String)
 
 <a id="nestedobjatt--db_services--infrastructure--storage_config--azure_net_app_config"></a>
-### Nested Schema for `db_services.infrastructure.storage_config.provider`
+### Nested Schema for `db_services.infrastructure.storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -515,7 +517,7 @@ Read-Only:
 - `volume_type` (String)
 
 <a id="nestedobjatt--db_services--instances--archive_storage_config--azure_net_app_config"></a>
-### Nested Schema for `db_services.instances.archive_storage_config.volume_type`
+### Nested Schema for `db_services.instances.archive_storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -525,13 +527,13 @@ Read-Only:
 - `capacity_pool_name` (String)
 - `delegated_subnet_id` (String)
 - `delegated_subnet_name` (String)
-- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--instances--archive_storage_config--volume_type--encryption_key_info))
+- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--instances--archive_storage_config--azure_net_app_config--encryption_key_info))
 - `network_features` (String)
 - `service_level` (String)
 - `volume_name` (String)
 
-<a id="nestedobjatt--db_services--instances--archive_storage_config--volume_type--encryption_key_info"></a>
-### Nested Schema for `db_services.instances.archive_storage_config.volume_type.encryption_key_info`
+<a id="nestedobjatt--db_services--instances--archive_storage_config--azure_net_app_config--encryption_key_info"></a>
+### Nested Schema for `db_services.instances.archive_storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -543,7 +545,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--db_services--instances--archive_storage_config--fsx_net_app_config"></a>
-### Nested Schema for `db_services.instances.archive_storage_config.volume_type`
+### Nested Schema for `db_services.instances.archive_storage_config.fsx_net_app_config`
 
 Read-Only:
 
@@ -580,7 +582,7 @@ Read-Only:
 - `provider` (String)
 
 <a id="nestedobjatt--db_services--instances--compute_config--exadata_config"></a>
-### Nested Schema for `db_services.instances.compute_config.provider`
+### Nested Schema for `db_services.instances.compute_config.exadata_config`
 
 Read-Only:
 
@@ -684,7 +686,7 @@ Read-Only:
 - `volume_type` (String)
 
 <a id="nestedobjatt--db_services--instances--storage_config--azure_net_app_config"></a>
-### Nested Schema for `db_services.instances.storage_config.volume_type`
+### Nested Schema for `db_services.instances.storage_config.azure_net_app_config`
 
 Read-Only:
 
@@ -694,13 +696,13 @@ Read-Only:
 - `capacity_pool_name` (String)
 - `delegated_subnet_id` (String)
 - `delegated_subnet_name` (String)
-- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--instances--storage_config--volume_type--encryption_key_info))
+- `encryption_key_info` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--instances--storage_config--azure_net_app_config--encryption_key_info))
 - `network_features` (String)
 - `service_level` (String)
 - `volume_name` (String)
 
-<a id="nestedobjatt--db_services--instances--storage_config--volume_type--encryption_key_info"></a>
-### Nested Schema for `db_services.instances.storage_config.volume_type.encryption_key_info`
+<a id="nestedobjatt--db_services--instances--storage_config--azure_net_app_config--encryption_key_info"></a>
+### Nested Schema for `db_services.instances.storage_config.azure_net_app_config.encryption_key_info`
 
 Read-Only:
 
@@ -712,7 +714,7 @@ Read-Only:
 
 
 <a id="nestedobjatt--db_services--instances--storage_config--fsx_net_app_config"></a>
-### Nested Schema for `db_services.instances.storage_config.volume_type`
+### Nested Schema for `db_services.instances.storage_config.fsx_net_app_config`
 
 Read-Only:
 
@@ -776,7 +778,7 @@ Read-Only:
 - `pre_script_info` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--refresh_info--script_info--pre_script_info))
 
 <a id="nestedobjatt--db_services--refresh_info--script_info--post_script_info"></a>
-### Nested Schema for `db_services.refresh_info.script_info.pre_script_info`
+### Nested Schema for `db_services.refresh_info.script_info.post_script_info`
 
 Read-Only:
 
@@ -867,15 +869,15 @@ Read-Only:
 - `private_link` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--service_connectivity--update_in_progress_info--private_link))
 
 <a id="nestedobjatt--db_services--service_connectivity--update_in_progress_info--computes_connectivity"></a>
-### Nested Schema for `db_services.service_connectivity.update_in_progress_info.private_link`
+### Nested Schema for `db_services.service_connectivity.update_in_progress_info.computes_connectivity`
 
 Read-Only:
 
 - `compute_resource_id` (String)
-- `port_access_config` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--service_connectivity--update_in_progress_info--private_link--port_access_config))
+- `port_access_config` (List of Object) (see [below for nested schema](#nestedobjatt--db_services--service_connectivity--update_in_progress_info--computes_connectivity--port_access_config))
 
-<a id="nestedobjatt--db_services--service_connectivity--update_in_progress_info--private_link--port_access_config"></a>
-### Nested Schema for `db_services.service_connectivity.update_in_progress_info.private_link.port_access_config`
+<a id="nestedobjatt--db_services--service_connectivity--update_in_progress_info--computes_connectivity--port_access_config"></a>
+### Nested Schema for `db_services.service_connectivity.update_in_progress_info.computes_connectivity.port_access_config`
 
 Read-Only:
 
@@ -967,5 +969,3 @@ Read-Only:
 - `submitted_at` (String)
 - `update_info` (Map of String)
 - `update_type` (String)
-
-

--- a/docs/data-sources/db_snapshot.md
+++ b/docs/data-sources/db_snapshot.md
@@ -107,5 +107,3 @@ Read-Only:
 Read-Only:
 
 - `users` (List of String)
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ terraform {
   required_providers {
     tessell = {
       source  = "tessell-cloud/tessell"
-      version = "0.0.24"
+      version = "0.0.29"
     }
   }
 }

--- a/docs/resources/db_service.md
+++ b/docs/resources/db_service.md
@@ -405,7 +405,6 @@ resource "tessell_db_service" "example" {
 - `description` (String) DB Service's description
 - `edition` (String)
 - `enable_deletion_protection` (Boolean) Specify whether to enable deletion protection for the DB Service
-- `enable_perf_insights` (Boolean) This field specifies whether to enable performance insights for the DB Service.
 - `enable_stop_protection` (Boolean) This field specifies whether to enable stop protection for the DB Service. If this is enabled, the stop for the DB Service would be disallowed until this setting is disabled.
 - `expected_status` (String) If provided, invoke the DB Service start/stop API
 - `instances` (Block List) Instances associated with this DB Service (see [below for nested schema](#nestedblock--instances))
@@ -524,6 +523,7 @@ Optional:
 - `multi_tenant` (Boolean) Specify whether the DB Service is multi-tenant.
 - `national_character_set` (String) The national-character-set for the database
 - `option_profile_id` (String) The options profile for the database
+- `options_profile` (String) The options profile for the database
 - `parameter_profile_id` (String) The parameter profile id for the database
 - `sid` (String) SID for oracle database
 
@@ -544,6 +544,7 @@ Optional:
 
 - `ad_domain_id` (String) Active Directory Domain ID
 - `option_profile_id` (String) The options profile for the database
+- `option_profile_name` (String)
 - `parameter_profile_id` (String) The parameter profile ID for the database
 - `proxy_port` (Number)
 
@@ -564,6 +565,7 @@ Optional:
 
 - `ad_domain_id` (String) Active Directory Domain ID
 - `agent_service_account_user` (String)
+- `instance_name` (String) The named instance for SQL Server database (max 16 characters as per SQL Server limitation)
 - `parameter_profile_id` (String) The parameter profile ID for the database
 - `service_account_user` (String)
 
@@ -963,7 +965,8 @@ Optional:
 
 Optional:
 
-- `option_profile_id` (String) The options profile for the database
+- `option_profile_id` (String) The option profile id for the database
+- `options_profile` (String) The options profile for the database
 - `parameter_profile_id` (String) The parameter profile id for the database
 - `username` (String) Username for the oracle database
 
@@ -1019,7 +1022,6 @@ Optional:
 
 Required:
 
-- `compute_type` (String) The compute used for creation of the Tessell Service Instance
 - `instance_group_name` (String) Name of the instance group
 - `name` (String) Name of the DB Service Instance
 - `region` (String) DB Service Instance's cloud region
@@ -1033,6 +1035,7 @@ Optional:
 - `aws_infra_config` (Block List) (see [below for nested schema](#nestedblock--instances--aws_infra_config))
 - `compute_config` (Block List, Max: 1) (see [below for nested schema](#nestedblock--instances--compute_config))
 - `compute_id` (String) The associated compute identifier
+- `compute_type` (String) The compute used for creation of the Tessell Service Instance
 - `data_volume_iops` (Number)
 - `enable_perf_insights` (Boolean)
 - `encryption_key` (String) The encryption key name which is used to encrypt the data at rest
@@ -1248,10 +1251,13 @@ Optional:
 Required:
 
 - `infrastructure_id` (String)
+- `vm_cluster_id` (String)
+
+Optional:
+
 - `infrastructure_name` (String)
 - `memory` (Number)
 - `vcpus` (Number)
-- `vm_cluster_id` (String)
 - `vm_cluster_name` (String)
 
 
@@ -1278,6 +1284,7 @@ Optional:
 Optional:
 
 - `client_azure_subscription_ids` (List of String) The list of Azure subscription Ids. This is only applicable for DB Services hosted on AZURE.
+- `id` (String)
 - `private_link_service_alias` (String) The Azure private link service alias
 - `service_principals` (List of String) The list of AWS account principals that are currently enabled. This is only applicable for DB Services hosted on AWS.
 - `status` (String)
@@ -1285,7 +1292,6 @@ Optional:
 Read-Only:
 
 - `endpoint_service_name` (String) The configured endpoint as a result of configuring the service-principals
-- `id` (String) The ID of this resource.
 
 
 <a id="nestedblock--instances--storage_config"></a>
@@ -1911,6 +1917,7 @@ Read-Only:
 - `snapshot_id` (String)
 - `snapshot_name` (String)
 - `snapshot_time` (String)
+- `storage_provider` (String)
 - `tessell_service` (String)
 - `tessell_service_id` (String)
 
@@ -2028,5 +2035,3 @@ Read-Only:
 - `submitted_at` (String)
 - `update_info` (Map of String)
 - `update_type` (String)
-
-

--- a/docs/resources/db_service_delete_schedule.md
+++ b/docs/resources/db_service_delete_schedule.md
@@ -43,5 +43,3 @@ resource "tessell_db_service_delete_schedule" "delete_schedule_f986a9af" {
 Optional:
 
 - `retain_availability_machine` (Boolean) If specified as true, the associated Availability Machine (snapshots, sanitized-snapshots, logs) would be retained
-
-

--- a/docs/resources/db_service_start_stop_schedule.md
+++ b/docs/resources/db_service_start_stop_schedule.md
@@ -97,5 +97,3 @@ Optional:
 Read-Only:
 
 - `schedule_counter` (Number)
-
-

--- a/internal/client/availability_machine.go
+++ b/internal/client/availability_machine.go
@@ -20,13 +20,13 @@ func (c *Client) GetAvailabilityMachine(id string) (*model.DMMConsumerView, int,
 		return nil, statusCode, err
 	}
 
-	tessellDMMServiceConsumerDTO := model.DMMConsumerView{}
-	err = json.Unmarshal(body, &tessellDMMServiceConsumerDTO)
+	dmmConsumerView := model.DMMConsumerView{}
+	err = json.Unmarshal(body, &dmmConsumerView)
 	if err != nil {
 		return nil, statusCode, err
 	}
 
-	return &tessellDMMServiceConsumerDTO, statusCode, nil
+	return &dmmConsumerView, statusCode, nil
 }
 
 func (c *Client) GetAvailabilityMachines(name string, status string, engineType string, loadAcls bool, owners []string) (*model.GetDMMsServiceView, int, error) {

--- a/internal/model/db_backup.go
+++ b/internal/model/db_backup.go
@@ -1,8 +1,8 @@
 package model
 
 type BackupSourceInfo struct {
-	SourceSnapshotId *string `json:"sourceSnapshotId,omitempty"` // ID of snapshot from which this backup was created
-	SnapshotName     *string `json:"snapshotName,omitempty"`     // Name of snapshot from which this backup was created
+	SourceSnapshotId *string `json:"sourceSnapshotId,omitempty"` // ID of the snapshot from which this backup was created
+	SnapshotName     *string `json:"snapshotName,omitempty"`     // Name of the snapshot from which this backup was created
 	SnapshotTime     *string `json:"snapshotTime,omitempty"`     // Capture time of snapshot from which this backup was created
 }
 

--- a/internal/model/db_service.go
+++ b/internal/model/db_service.go
@@ -17,6 +17,7 @@ type TessellServiceClonedFromInfo struct {
 	SnapshotTime          *string `json:"snapshotTime,omitempty"`          // DB Service snapshot capture time
 	PITRTime              *string `json:"pitrTime,omitempty"`              // If the database was created using a Point-In-Time mechanism, it specifies the timestamp in UTC
 	MaximumRecoverability *bool   `json:"maximumRecoverability,omitempty"` // If the service was created using a maximum recoverability from the parent service
+	StorageProvider       *string `json:"storageProvider,omitempty"`
 }
 
 type TfTessellServiceInfrastructureInfo struct {
@@ -193,6 +194,7 @@ type TessellServiceSqlServerEngineConfig struct {
 	AdDomainId              *string `json:"adDomainId,omitempty"`         // Active Directory Domain ID
 	ServiceAccountUser      *string `json:"serviceAccountUser,omitempty"`
 	AgentServiceAccountUser *string `json:"agentServiceAccountUser,omitempty"`
+	InstanceName            *string `json:"instanceName,omitempty"` // The named instance for SQL Server database (max 16 characters as per SQL Server limitation)
 }
 
 type TessellServiceApacheKafkaEngineConfig struct {
@@ -248,8 +250,8 @@ type DatabaseConfiguration struct {
 type OracleDatabaseConfig struct {
 	ParameterProfileId *string `json:"parameterProfileId,omitempty"` // The parameter profile id for the database
 	OptionsProfile     *string `json:"optionsProfile,omitempty"`     // The options profile for the database
-	OptionProfileId    *string `json:"optionProfileId,omitempty"`    // The options profile for the database
 	Username           *string `json:"username,omitempty"`           // Username for the oracle database
+	OptionProfileId    *string `json:"optionProfileId,omitempty"`    // The option profile id for the database
 }
 
 type PostgresqlDatabaseConfig struct {
@@ -540,6 +542,7 @@ type SqlServerEngineConfigPayload struct {
 	AdDomainId               *string             `json:"adDomainId,omitempty"` // Active Directory Domain id
 	ServiceAccountCreds      *CredentialsPayload `json:"serviceAccountCreds,omitempty"`
 	AgentServiceAccountCreds *CredentialsPayload `json:"agentServiceAccountCreds,omitempty"`
+	InstanceName             *string             `json:"instanceName,omitempty"` // The named instance for SQL Server database (max 16 characters as per SQL Server limitation)
 }
 
 type CredentialsPayload struct {

--- a/internal/resource/db_service/data_source_db_service.go
+++ b/internal/resource/db_service/data_source_db_service.go
@@ -215,6 +215,11 @@ func DataSourceDBService() *schema.Resource {
 							Description: "If the service was created using a maximum recoverability from the parent service",
 							Computed:    true,
 						},
+						"storage_provider": {
+							Type:        schema.TypeString,
+							Description: "",
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -868,7 +873,7 @@ func DataSourceDBService() *schema.Resource {
 										Description: "",
 										Computed:    true,
 									},
-									"options_profile": {
+									"option_profile_name": {
 										Type:        schema.TypeString,
 										Description: "",
 										Computed:    true,
@@ -929,6 +934,11 @@ func DataSourceDBService() *schema.Resource {
 									"agent_service_account_user": {
 										Type:        schema.TypeString,
 										Description: "",
+										Computed:    true,
+									},
+									"instance_name": {
+										Type:        schema.TypeString,
+										Description: "The named instance for SQL Server database (max 16 characters as per SQL Server limitation)",
 										Computed:    true,
 									},
 								},
@@ -1926,14 +1936,14 @@ func DataSourceDBService() *schema.Resource {
 													Description: "The options profile for the database",
 													Computed:    true,
 												},
-												"option_profile_id": {
-													Type:        schema.TypeString,
-													Description: "The options profile for the database",
-													Computed:    true,
-												},
 												"username": {
 													Type:        schema.TypeString,
 													Description: "Username for the oracle database",
+													Computed:    true,
+												},
+												"option_profile_id": {
+													Type:        schema.TypeString,
+													Description: "The option profile id for the database",
 													Computed:    true,
 												},
 											},

--- a/internal/resource/db_service/data_source_db_services.go
+++ b/internal/resource/db_service/data_source_db_services.go
@@ -222,6 +222,11 @@ func DataSourceDBServices() *schema.Resource {
 										Description: "If the service was created using a maximum recoverability from the parent service",
 										Computed:    true,
 									},
+									"storage_provider": {
+										Type:        schema.TypeString,
+										Description: "",
+										Computed:    true,
+									},
 								},
 							},
 						},
@@ -875,7 +880,7 @@ func DataSourceDBServices() *schema.Resource {
 													Description: "",
 													Computed:    true,
 												},
-												"options_profile": {
+												"option_profile_name": {
 													Type:        schema.TypeString,
 													Description: "",
 													Computed:    true,
@@ -936,6 +941,11 @@ func DataSourceDBServices() *schema.Resource {
 												"agent_service_account_user": {
 													Type:        schema.TypeString,
 													Description: "",
+													Computed:    true,
+												},
+												"instance_name": {
+													Type:        schema.TypeString,
+													Description: "The named instance for SQL Server database (max 16 characters as per SQL Server limitation)",
 													Computed:    true,
 												},
 											},
@@ -1933,14 +1943,14 @@ func DataSourceDBServices() *schema.Resource {
 																Description: "The options profile for the database",
 																Computed:    true,
 															},
-															"option_profile_id": {
-																Type:        schema.TypeString,
-																Description: "The options profile for the database",
-																Computed:    true,
-															},
 															"username": {
 																Type:        schema.TypeString,
 																Description: "Username for the oracle database",
+																Computed:    true,
+															},
+															"option_profile_id": {
+																Type:        schema.TypeString,
+																Description: "The option profile id for the database",
 																Computed:    true,
 															},
 														},

--- a/internal/resource/db_service/resource_db_service.go
+++ b/internal/resource/db_service/resource_db_service.go
@@ -157,12 +157,6 @@ func ResourceDBService() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 			},
-			"enable_perf_insights": {
-				Type:        schema.TypeBool,
-				Description: "This field specifies whether to enable performance insights for the DB Service.",
-				Optional:    true,
-				Default:     true,
-			},
 			"owner": {
 				Type:        schema.TypeString,
 				Description: "DB Service owner email address",
@@ -258,6 +252,11 @@ func ResourceDBService() *schema.Resource {
 							Optional:    true,
 							ForceNew:    true,
 							Default:     false,
+						},
+						"storage_provider": {
+							Type:        schema.TypeString,
+							Description: "",
+							Optional:    true,
 						},
 					},
 				},
@@ -2261,6 +2260,12 @@ func ResourceDBService() *schema.Resource {
 										Optional:    true,
 										ForceNew:    true,
 									},
+									"options_profile": {
+										Type:        schema.TypeString,
+										Description: "The options profile for the database",
+										Optional:    true,
+										Computed:    true,
+									},
 									"option_profile_id": {
 										Type:        schema.TypeString,
 										Description: "The options profile for the database",
@@ -2321,6 +2326,12 @@ func ResourceDBService() *schema.Resource {
 										Description: "",
 										Optional:    true,
 										ForceNew:    true,
+									},
+									"option_profile_name": {
+										Type:        schema.TypeString,
+										Description: "",
+										Optional:    true,
+										Computed:    true,
 									},
 									"option_profile_id": {
 										Type:        schema.TypeString,
@@ -2391,6 +2402,12 @@ func ResourceDBService() *schema.Resource {
 									"agent_service_account_user": {
 										Type:        schema.TypeString,
 										Description: "",
+										Optional:    true,
+										ForceNew:    true,
+									},
+									"instance_name": {
+										Type:        schema.TypeString,
+										Description: "The named instance for SQL Server database (max 16 characters as per SQL Server limitation)",
 										Optional:    true,
 										ForceNew:    true,
 									},
@@ -2658,15 +2675,21 @@ func ResourceDBService() *schema.Resource {
 													Optional:    true,
 													ForceNew:    true,
 												},
-												"option_profile_id": {
+												"options_profile": {
 													Type:        schema.TypeString,
 													Description: "The options profile for the database",
 													Optional:    true,
-													ForceNew:    true,
+													Computed:    true,
 												},
 												"username": {
 													Type:        schema.TypeString,
 													Description: "Username for the oracle database",
+													Optional:    true,
+													ForceNew:    true,
+												},
+												"option_profile_id": {
+													Type:        schema.TypeString,
+													Description: "The option profile id for the database",
 													Optional:    true,
 													ForceNew:    true,
 												},
@@ -2947,7 +2970,8 @@ func ResourceDBService() *schema.Resource {
 						"compute_type": {
 							Type:        schema.TypeString,
 							Description: "The compute used for creation of the Tessell Service Instance",
-							Required:    true,
+							Optional:    true,
+							Computed:    true,
 						},
 						"aws_infra_config": {
 							Type:        schema.TypeList,
@@ -3271,31 +3295,37 @@ func ResourceDBService() *schema.Resource {
 													Type:        schema.TypeString,
 													Description: "",
 													Required:    true,
+													ForceNew:    true,
 												},
 												"infrastructure_name": {
 													Type:        schema.TypeString,
 													Description: "",
-													Required:    true,
+													Optional:    true,
+													Computed:    true,
 												},
 												"vm_cluster_id": {
 													Type:        schema.TypeString,
 													Description: "",
 													Required:    true,
+													ForceNew:    true,
 												},
 												"vm_cluster_name": {
 													Type:        schema.TypeString,
 													Description: "",
-													Required:    true,
+													Optional:    true,
+													Computed:    true,
 												},
 												"vcpus": {
 													Type:        schema.TypeInt,
 													Description: "",
-													Required:    true,
+													Optional:    true,
+													Computed:    true,
 												},
 												"memory": {
 													Type:        schema.TypeInt,
 													Description: "",
-													Required:    true,
+													Optional:    true,
+													Computed:    true,
 												},
 											},
 										},
@@ -3911,9 +3941,6 @@ func ResourceDBService() *schema.Resource {
 					names[name] = true
 					if role == "primary" {
 						primaryCount++
-						if primaryCount > 1 {
-							return fmt.Errorf("more than one instance has 'primary' role")
-						}
 					}
 				}
 				if primaryCount == 0 && len(instances) != 0 {


### PR DESCRIPTION
This PR adds Exadata support to the Tessell Terraform provider, refactors several nested schemas around clones/availability machines, and aligns documentation with the updated model.​

Summary
Introduce exadata_config under compute_config for clones and availability machines to model Exadata-specific compute settings.​

Restructure archive and primary storage configuration blocks to hang off archive_storage_config and storage_config instead of vpc, including Azure NetApp and FSx NetApp details.​

Clarify and rename multiple nested documentation sections (RPO policy schedules, backup content, sanitized content, DAPs) to match the underlying schema and field semantics.​

Exadata-related changes
Add exadata_config as a nested block under compute_config in availability machines clone instance schema, instead of treating it as part of a generic vpc block.​

Wire corresponding Exadata-related attributes in docs so Exadata-capable availability machines and clones are discoverable and accurately documented.​

Storage and clone config changes
Move Azure/FSx NetApp configuration under archive_storage_config and storage_config for clones and availability machines, updating IDs and headings for nested schemas accordingly.​

Keep provider/volume_type attributes while ensuring encryption key info and other properties are documented against the new parent blocks.​

Engine, monitoring, and profiles
Re-parent oracle_config, monitoring_config.perf_insights, option_profile, parameter_profile, private_link_info, connect_string, and updates_in_progress from vpc to their logical top-level blocks (e.g., engine_configuration, monitoring_config).​

Update headings and anchor IDs in availability machines docs to reflect these new parents so the generated docs match the Terraform schema layout.​

RPO and DAPs documentation fixes
Correct RPO policy documentation: distinguish standard_policy vs custom_policy, fix schedule sub-block names (daily, weekly, monthly, yearly, common_schedule, backup_start_time) and their anchors.​

Refine DAPs content info docs by renaming sections from sanitized_content to as_is_content and backup_content where appropriate, adjusting nested manual blocks and anchors to the right parent